### PR TITLE
Enabling facets for tags on Gmail and GitHub issues

### DIFF
--- a/config/config-github-issues.json
+++ b/config/config-github-issues.json
@@ -5,7 +5,8 @@
   "batchname": "GithubIssues",
   "filters": [
     "user",
-    "type"
+    "type",
+    "tags"
   ],
   "gsheetLastUpdated": "",
   "newestItemDate": ""


### PR DESCRIPTION
Facets for tags on Gmail and GitHub issues are already available in the document processor `iftt-norch-tools`, only needs to be used when indexing.
